### PR TITLE
Docker Image Building

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ LABEL desc "CMS-Detector and Vulnerability Scanner & exploiter"
 
 RUN apk add git && git clone https://github.com/anouarbensaad/VulnX.git VulnX
 WORKDIR VulnX
-RUN pip install -r ./pip/requirements.txt
-
+RUN pip install --upgrade pip ; pip install requests ;
 VOLUME [ "/VulnX" ]
-ENTRYPOINT [ "python3", "vulnx.py" ]
+ENTRYPOINT [ "python", "vulnx.py" ]
+CMD ["--help"]


### PR DESCRIPTION
while running a default container with vulnx image.. like `docker container run vulnx:latest`
you have the error from url args 
so you should be run with --help
i added 

```Dockerfile
CMD ["--help"]
```
and when you building the image there is an error in pip requirements. 
so you should be installed the packages manually and upgrade the pip version.

i added

```Dockerfile
RUN pip install --upgrade pip ; pip install requests ;
```