### PR TITLE
corrected installation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ VOLUME [ "$PATH" ]
 
 ```bash
 $ git clone https://github.com/anouarbensaad/vulnx.git
-$ cd VulnX
+$ cd vulnx
 $ chmod +x install.sh
 $ ./install.sh
 ```


### PR DESCRIPTION
there was a typo in the installation manual for `ubuntu` within the README.md.
> changed 
```bash
cd VulnX
```
to 
```bash
cd vulnx
```
a minor error that can be corrected via parent